### PR TITLE
Fix FASTA input handling and split safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ with torch.no_grad():
 ### Ultra fast embedding inference
 
 #### Preare the data
-Prepare a fasta file, same format as the `example/fasta/example_0.fasta` file. The fasta file should contain the sequences you want to embed. By running the following command, we will automatically collect all fasta files in the `example/fasta` directory and extract the embedding for each sequence.
+Prepare a FASTA file, same format as the `example/fasta/example_0.fasta` file. You can pass either a single FASTA file or a directory containing FASTA files. When you pass a directory, the command collects supported FASTA files in that directory and extracts embeddings for each sequence.
 
 
 #### Run your inference

--- a/tests/test_infer_and_split.py
+++ b/tests/test_infer_and_split.py
@@ -1,6 +1,14 @@
+import pytest
+import torch
 from Bio import SeqIO
 
-from unirna_tf.infer import prepare_seq, prepare_seq_dict
+from unirna_tf.infer import (
+    fasta_output_stem,
+    format_prediction_batch,
+    prepare_seq,
+    prepare_seq_dict,
+    resolve_fasta_inputs,
+)
 from unirna_tf.split import split_fasta
 
 
@@ -32,3 +40,103 @@ def test_split_fasta_creates_files(tmp_path):
         assert len(records) <= 2
 
     assert total_records == 3
+
+
+def test_resolve_fasta_inputs_accepts_single_file(tmp_path):
+    fasta_path = tmp_path / "sample.v1.fasta"
+    fasta_path.write_text(">seq1\nACGU\n")
+
+    assert resolve_fasta_inputs(str(fasta_path)) == [str(fasta_path)]
+
+
+def test_resolve_fasta_inputs_filters_directory_entries(tmp_path):
+    fasta_dir = tmp_path / "inputs"
+    fasta_dir.mkdir()
+    first = fasta_dir / "first.v1.fasta"
+    second = fasta_dir / "second.fa.gz"
+    ignored = fasta_dir / "notes.txt"
+    nested = fasta_dir / "nested"
+
+    first.write_text(">seq1\nACGU\n")
+    second.write_text(">seq2\nGGAA\n")
+    ignored.write_text("not fasta\n")
+    nested.mkdir()
+    (nested / "inside.fasta").write_text(">seq3\nCCUU\n")
+
+    assert resolve_fasta_inputs(str(fasta_dir)) == [str(first), str(second)]
+
+
+def test_resolve_fasta_inputs_rejects_colliding_output_names(tmp_path):
+    fasta_dir = tmp_path / "inputs"
+    fasta_dir.mkdir()
+    (fasta_dir / "sample.fa").write_text(">seq1\nACGU\n")
+    (fasta_dir / "sample.fasta").write_text(">seq2\nGGAA\n")
+
+    with pytest.raises(ValueError, match="overwrite the same output"):
+        resolve_fasta_inputs(str(fasta_dir))
+
+
+def test_fasta_output_stem_preserves_earlier_dots():
+    assert fasta_output_stem("/tmp/sample.v1.fasta") == "sample.v1"
+    assert fasta_output_stem("/tmp/sample.v2.fa.gz") == "sample.v2"
+
+
+def test_format_prediction_batch_whole_seq_includes_padding_metadata():
+    class DummyPredictions:
+        def __init__(self):
+            self.pooler_output = torch.tensor([[1.0, 2.0], [3.0, 4.0]])
+            self.last_hidden_state = torch.tensor(
+                [
+                    [[10.0, 11.0], [12.0, 13.0], [0.0, 0.0]],
+                    [[20.0, 21.0], [0.0, 0.0], [0.0, 0.0]],
+                ]
+            )
+
+    attention_mask = torch.tensor([[1, 1, 0], [1, 0, 0]])
+    batch = format_prediction_batch(DummyPredictions(), attention_mask, save_whole_seq=True)
+
+    assert set(batch) == {"pooler_output", "last_hidden_state", "attention_mask", "sequence_lengths"}
+    assert torch.equal(batch["attention_mask"], attention_mask)
+    assert torch.equal(batch["sequence_lengths"], torch.tensor([2, 1]))
+    assert batch["pooler_output"].dtype == torch.float32
+    assert batch["last_hidden_state"].dtype == torch.float32
+
+
+def test_format_prediction_batch_pooled_mode_returns_tensor():
+    class DummyPredictions:
+        def __init__(self):
+            self.pooler_output = torch.tensor([[1.0, 2.0]])
+
+    attention_mask = torch.tensor([[1, 1]])
+    batch = format_prediction_batch(DummyPredictions(), attention_mask, save_whole_seq=False)
+
+    assert torch.equal(batch, torch.tensor([[1.0, 2.0]]))
+
+
+@pytest.mark.parametrize("num_files", [0, -1])
+def test_split_fasta_rejects_non_positive_shard_counts(tmp_path, num_files):
+    fasta_path = tmp_path / "sample.fasta"
+    fasta_path.write_text(">seq1\nACGU\n")
+
+    with pytest.raises(ValueError, match="positive integer"):
+        split_fasta(str(fasta_path), str(tmp_path / "splits"), num_files)
+
+
+def test_split_fasta_caps_output_count_to_records(tmp_path):
+    fasta_path = tmp_path / "sample.fasta"
+    fasta_path.write_text(">seq1\nACGU\n>seq2\nGGAA\n")
+
+    out_dir = tmp_path / "splits"
+    split_fasta(str(fasta_path), str(out_dir), 5)
+
+    split_files = sorted(out_dir.glob("split_*.fasta"))
+    assert len(split_files) == 2
+    assert [len(list(SeqIO.parse(str(file_path), "fasta"))) for file_path in split_files] == [1, 1]
+
+
+def test_split_fasta_rejects_empty_input(tmp_path):
+    fasta_path = tmp_path / "empty.fasta"
+    fasta_path.write_text("")
+
+    with pytest.raises(ValueError, match="has no records"):
+        split_fasta(str(fasta_path), str(tmp_path / "splits"), 2)

--- a/unirna_tf/infer.py
+++ b/unirna_tf/infer.py
@@ -1,7 +1,8 @@
 import argparse
 import os
 import tempfile
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Dict, List, Optional
 
 import ray
 import torch
@@ -13,6 +14,10 @@ from tqdm import tqdm
 from transformers import AutoTokenizer
 
 from unirna_tf import UniRNAModels
+
+
+FASTA_SUFFIXES = {".fa", ".fasta", ".fna", ".ffn", ".faa", ".frn"}
+COMPRESSION_SUFFIXES = {".gz", ".bz2", ".xz"}
 
 
 def prepare_seq(fasta_path):
@@ -29,6 +34,76 @@ def prepare_seq_dict(fasta_path):
     for record in tqdm(SeqIO.parse(fasta_path, "fasta"), desc="Prepare fasta file"):
         seq_list.append({"seq": str(record.seq)})
     return seq_list
+
+
+def is_fasta_file(path: Path) -> bool:
+    """Return whether the path looks like a FASTA file."""
+    suffixes = [suffix.lower() for suffix in path.suffixes]
+    if not suffixes:
+        return False
+    if suffixes[-1] in FASTA_SUFFIXES:
+        return True
+    return len(suffixes) >= 2 and suffixes[-1] in COMPRESSION_SUFFIXES and suffixes[-2] in FASTA_SUFFIXES
+
+
+def fasta_output_stem(fasta_path: str) -> str:
+    """Build a stable output stem without dropping earlier dots."""
+    path = Path(fasta_path)
+    name = path.name
+    while True:
+        stem, suffix = os.path.splitext(name)
+        if not suffix:
+            break
+        suffix = suffix.lower()
+        if suffix in COMPRESSION_SUFFIXES or suffix in FASTA_SUFFIXES:
+            name = stem
+            continue
+        break
+    return name
+
+
+def resolve_fasta_inputs(fasta_path: str) -> List[str]:
+    """Resolve a FASTA file or a directory of FASTA files."""
+    input_path = Path(fasta_path)
+    if not input_path.exists():
+        raise FileNotFoundError(f"FASTA input path does not exist: {fasta_path}")
+
+    if input_path.is_file():
+        if not is_fasta_file(input_path):
+            raise ValueError(f"Input file is not a supported FASTA file: {fasta_path}")
+        return [str(input_path)]
+
+    if not input_path.is_dir():
+        raise ValueError(f"FASTA input path must be a file or directory: {fasta_path}")
+
+    file_paths = sorted(str(path) for path in input_path.iterdir() if path.is_file() and is_fasta_file(path))
+    if not file_paths:
+        raise ValueError(f"No FASTA files found in directory: {fasta_path}")
+
+    stems = {}
+    for file_path in file_paths:
+        stem = fasta_output_stem(file_path)
+        if stem in stems:
+            raise ValueError(
+                f"Multiple FASTA inputs would overwrite the same output '{stem}.pt': {stems[stem]} and {file_path}"
+            )
+        stems[stem] = file_path
+    return file_paths
+
+
+def format_prediction_batch(predictions, attention_mask: torch.Tensor, save_whole_seq: bool):
+    """Convert model outputs into a serializable batch payload."""
+    pooler_output = predictions.pooler_output.float().cpu()
+    if not save_whole_seq:
+        return pooler_output
+
+    attention_mask = attention_mask.to(dtype=torch.int64).cpu()
+    return {
+        "pooler_output": pooler_output,
+        "last_hidden_state": predictions.last_hidden_state.float().cpu(),
+        "attention_mask": attention_mask,
+        "sequence_lengths": attention_mask.sum(dim=1),
+    }
 
 
 def add_model_args(parser: argparse.ArgumentParser) -> None:
@@ -69,7 +144,7 @@ def add_data_args(parser: argparse.ArgumentParser) -> None:
         "-fp",
         type=str,
         required=True,
-        help="Path to the fasta file containing the sequences.",
+        help="Path to a FASTA file or a directory containing FASTA files.",
     )
     parser.add_argument(
         "--output_dir",
@@ -151,20 +226,17 @@ class UniRNAPredictor:
         dataloader = torch.utils.data.DataLoader(dataset, batch_size=self.batch_size, shuffle=False, num_workers=8)
         results = []
         print(f"Predicting {fasta_path}")
-        fasta_basename = os.path.basename(fasta_path)
-        fasta_name = fasta_basename.split(".")[0]
+        fasta_name = fasta_output_stem(fasta_path)
 
         for tokens in tqdm(dataloader, desc=f"Predicting {fasta_name}"):
+            attention_mask = tokens["attention_mask"]
             with torch.inference_mode():
                 predictions = self.model(
                     tokens["input_ids"].to(self.device),
-                    tokens["attention_mask"].to(self.device),
+                    attention_mask.to(self.device),
                     output_attentions=False,
                 )
-            if self.save_whole_seq:
-                results.append((predictions.pooler_output.float().cpu(), predictions.last_hidden_state.float().cpu()))
-            else:
-                results.append(predictions.pooler_output.float().cpu())
+            results.append(format_prediction_batch(predictions, attention_mask, self.save_whole_seq))
 
         torch.save(results, f"{output_dir}/{fasta_name}.pt")
 
@@ -177,9 +249,7 @@ def cli_main():
 
     start = time.time()
     args = parser_args()
-    file_paths = []
-    for file_name in os.listdir(args.fasta_path):
-        file_paths.append(os.path.join(args.fasta_path, file_name))
+    file_paths = resolve_fasta_inputs(args.fasta_path)
 
     num_actors = args.concurrency
 

--- a/unirna_tf/split.py
+++ b/unirna_tf/split.py
@@ -7,28 +7,36 @@ from tqdm import tqdm
 
 def split_fasta(input_file, output_dir, num_files):
     """Split a FASTA file into ``num_files`` shards with roughly even record counts."""
-    total_records = sum(1 for _ in tqdm(SeqIO.parse(input_file, "fasta"), desc="Counting sequences"))
     num_files = int(num_files)
+    if num_files <= 0:
+        raise ValueError(f"num_files must be a positive integer, got {num_files}")
 
-    records_per_file = total_records // num_files
-    if total_records % num_files != 0:
+    total_records = sum(1 for _ in tqdm(SeqIO.parse(input_file, "fasta"), desc="Counting sequences"))
+    if total_records == 0:
+        raise ValueError(f"Input FASTA has no records: {input_file}")
+
+    num_output_files = min(num_files, total_records)
+
+    records_per_file = total_records // num_output_files
+    if total_records % num_output_files != 0:
         records_per_file += 1
 
     if not os.path.exists(output_dir):
         os.makedirs(output_dir)
 
-    record_iter = SeqIO.parse(open(input_file), "fasta")
-    for i in tqdm(range(num_files), desc="Writing splits"):
-        filename = os.path.join(output_dir, "split_{}.fasta".format(i))
-        with open(filename, "w") as out_handle:
-            count = 0
-            while count < records_per_file:
-                try:
-                    seq_record = next(record_iter)
-                    SeqIO.write(seq_record, out_handle, "fasta")
-                    count += 1
-                except StopIteration:
-                    break  # Reached the end of the source FASTA
+    with open(input_file) as in_handle:
+        record_iter = SeqIO.parse(in_handle, "fasta")
+        for i in tqdm(range(num_output_files), desc="Writing splits"):
+            filename = os.path.join(output_dir, "split_{}.fasta".format(i))
+            with open(filename, "w") as out_handle:
+                count = 0
+                while count < records_per_file:
+                    try:
+                        seq_record = next(record_iter)
+                        SeqIO.write(seq_record, out_handle, "fasta")
+                        count += 1
+                    except StopIteration:
+                        break  # Reached the end of the source FASTA
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- let the inference CLI accept either a single FASTA file or a directory of FASTA files while filtering unsupported inputs and preventing output-name collisions
- preserve stable output stems for multi-dot filenames and include attention metadata when saving whole-sequence outputs so padding stays identifiable downstream
- validate FASTA splitting inputs, avoid empty shard files, and cover the new behavior with focused regression tests and README updates

## Testing
- PYTHONPATH=. pytest -q