### PR TITLE
Fix packaging and checkpoint conversion behavior

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,13 @@ classifiers = [
 requires-python = ">=3"
 dynamic = ["version"]
 dependencies = [
+    "biopython",
+    "chanfig",
+    "datasets",
+    "packaging",
+    "ray",
+    "torch",
+    "tqdm",
     "transformers"
 ]
 
@@ -40,6 +47,7 @@ repository = "http://git.dp.tech/macromolecule/unirna_transformers"
 documentation = "http://git.dp.tech/macromolecule/unirna_transformers"
 
 [project.scripts]
+unirna_build_model = "unirna_tf.build_model:cli_main"
 unirna_infer = "unirna_tf.infer:cli_main"
 
 [tool.setuptools]

--- a/tests/test_build_model.py
+++ b/tests/test_build_model.py
@@ -1,0 +1,122 @@
+from pathlib import Path
+
+import pytest
+import torch
+
+from unirna_tf.build_model import _align_vocab_size, convert, convert_ckpt
+
+
+def _make_raw_model_state(vocab_size=10, hidden_size=8, num_layers=1):
+    model = {
+        "embed_tokens.weight": torch.arange(vocab_size * hidden_size, dtype=torch.float32).reshape(vocab_size, hidden_size),
+        "emb_layer_norm_before.weight": torch.ones(hidden_size),
+        "emb_layer_norm_before.bias": torch.zeros(hidden_size),
+        "emb_layer_norm_after.weight": torch.ones(hidden_size),
+        "emb_layer_norm_after.bias": torch.zeros(hidden_size),
+        "lm_head.dense.weight": torch.ones(hidden_size, hidden_size),
+        "lm_head.dense.bias": torch.zeros(hidden_size),
+        "lm_head.layer_norm.weight": torch.ones(hidden_size),
+        "lm_head.layer_norm.bias": torch.zeros(hidden_size),
+        "lm_head.out_proj.weight": torch.arange(vocab_size * hidden_size, dtype=torch.float32).reshape(vocab_size, hidden_size),
+        "lm_head.out_proj.bias": torch.arange(vocab_size, dtype=torch.float32),
+        "layers": {},
+    }
+    for layer_idx in range(num_layers):
+        model["layers"][str(layer_idx)] = {
+            "self_attn.in_proj.weight": torch.arange(hidden_size * 3 * hidden_size, dtype=torch.float32).reshape(
+                hidden_size * 3, hidden_size
+            ),
+            "self_attn.in_proj.bias": torch.arange(hidden_size * 3, dtype=torch.float32),
+            "self_attn.rot_emb.inv_freq": torch.arange(hidden_size // 2, dtype=torch.float32),
+            "self_attn.out_proj.weight": torch.ones(hidden_size, hidden_size),
+            "self_attn.out_proj.bias": torch.zeros(hidden_size),
+            "self_attn_layer_norm.weight": torch.ones(hidden_size),
+            "self_attn_layer_norm.bias": torch.zeros(hidden_size),
+            "fc1.weight": torch.ones(hidden_size * 2, hidden_size),
+            "fc1.bias": torch.zeros(hidden_size * 2),
+            "fc2.weight": torch.ones(hidden_size, hidden_size * 2),
+            "fc2.bias": torch.zeros(hidden_size),
+            "final_layer_norm.weight": torch.ones(hidden_size),
+            "final_layer_norm.bias": torch.zeros(hidden_size),
+        }
+    return model
+
+
+def test_align_vocab_size_updates_embedding_and_decoder_tensors():
+    weights = convert_ckpt(_make_raw_model_state(vocab_size=10, hidden_size=8))
+
+    _align_vocab_size(weights, 6)
+
+    assert weights["embeddings.word_embeddings.weight"].shape == (6, 8)
+    assert weights["lm_head.decoder.weight"].shape == (6, 8)
+    assert weights["lm_head.decoder.bias"].shape == (6,)
+    assert torch.equal(weights["embeddings.word_embeddings.weight"], torch.arange(48, dtype=torch.float32).reshape(6, 8))
+
+
+def test_align_vocab_size_rejects_inconsistent_checkpoint_tensors():
+    weights = convert_ckpt(_make_raw_model_state(vocab_size=10, hidden_size=8))
+    weights["lm_head.decoder.bias"] = weights["lm_head.decoder.bias"][:8]
+
+    with pytest.raises(ValueError, match="Checkpoint vocab tensors are inconsistent"):
+        _align_vocab_size(weights, 8)
+
+
+def test_convert_writes_output_next_to_checkpoint_and_preserves_existing_files(tmp_path, monkeypatch):
+    checkpoint_dir = tmp_path / "checkpoints"
+    checkpoint_dir.mkdir()
+    checkpoint_path = checkpoint_dir / "unirna_L8_H512_demo.pt"
+    torch.save({"model": _make_raw_model_state(vocab_size=10, hidden_size=512)}, checkpoint_path)
+
+    output_dir = checkpoint_dir / "unirna_L8_H512_demo"
+    output_dir.mkdir()
+    sentinel = output_dir / "keep.txt"
+    sentinel.write_text("keep me")
+
+    cwd_dir = tmp_path / "unirna_L8_H512_demo"
+    cwd_dir.mkdir()
+    unrelated = cwd_dir / "cwd.txt"
+    unrelated.write_text("unrelated")
+
+    monkeypatch.chdir(tmp_path)
+    convert(str(checkpoint_path), version="single")
+
+    assert (output_dir / "config.json").exists()
+    assert (output_dir / "pytorch_model.bin").exists()
+    assert sentinel.read_text() == "keep me"
+    assert unrelated.read_text() == "unrelated"
+    assert not (cwd_dir / "config.json").exists()
+
+
+def test_convert_rejects_invalid_version(tmp_path):
+    checkpoint_path = tmp_path / "unirna_L8_H512_demo.pt"
+    torch.save({"model": _make_raw_model_state(vocab_size=10, hidden_size=512)}, checkpoint_path)
+
+    with pytest.raises(ValueError, match="Unsupported tokenizer version"):
+        convert(str(checkpoint_path), version="unknown")
+
+
+def test_convert_rejects_non_positive_gene_dimensions(tmp_path):
+    checkpoint_path = tmp_path / "gene.pt"
+    torch.save({"model": _make_raw_model_state(vocab_size=10, hidden_size=64)}, checkpoint_path)
+
+    with pytest.raises(ValueError, match="requires positive values"):
+        convert(str(checkpoint_path), version="bpe", num_hidden_layers=0, hidden_size=64, vocab_size=10)
+
+
+def test_pyproject_declares_runtime_dependencies_and_build_script():
+    pyproject = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    content = pyproject.read_text()
+
+    for required in [
+        '"biopython"',
+        '"chanfig"',
+        '"datasets"',
+        '"packaging"',
+        '"ray"',
+        '"torch"',
+        '"tqdm"',
+        '"transformers"',
+        'unirna_build_model = "unirna_tf.build_model:cli_main"',
+        'unirna_infer = "unirna_tf.infer:cli_main"',
+    ]:
+        assert required in content

--- a/unirna_tf/build_model.py
+++ b/unirna_tf/build_model.py
@@ -1,12 +1,17 @@
+import argparse
 import os
 import shutil
 import sys
 from collections import OrderedDict
+from pathlib import Path
 
 import torch
 from chanfig import NestedDict
 
 from unirna_tf.config import build_config, build_config_GENE
+
+
+SUPPORTED_TOKENIZER_VERSIONS = {"single", "bpe", "plant_bpe"}
 
 
 def convert_ckpt(ckpt):
@@ -54,43 +59,137 @@ def convert_ckpt(ckpt):
     return weights
 
 
-def convert(path, version: int = 0, num_hidden_layers: int = 12, hidden_size: int = 768, vocab_size: int = 10):
-    ckpt = torch.load(path)
+def _validate_version(version: str) -> str:
+    if version is None:
+        return "single"
+    normalized = str(version).strip().lower()
+    if normalized not in SUPPORTED_TOKENIZER_VERSIONS:
+        valid = ", ".join(sorted(SUPPORTED_TOKENIZER_VERSIONS))
+        raise ValueError(f"Unsupported tokenizer version '{version}'. Expected one of: {valid}.")
+    return normalized
+
+
+def _validate_gene_dims(num_hidden_layers: int, hidden_size: int, vocab_size: int) -> tuple[int, int, int]:
+    try:
+        validated = (int(num_hidden_layers), int(hidden_size), int(vocab_size))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("GENE conversion requires integer values for layers, hidden size, and vocab size.") from exc
+    if any(value <= 0 for value in validated):
+        raise ValueError("GENE conversion requires positive values for layers, hidden size, and vocab size.")
+    return validated
+
+
+def _resolve_output_dir(path: str) -> Path:
+    checkpoint_path = Path(path).expanduser().resolve()
+    return checkpoint_path.with_suffix("")
+
+
+def _prepare_output_dir(output_dir: Path, tokenizer_name: str) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tokenizer_dir = Path(__file__).resolve().parent / "tokenizer" / tokenizer_name
+    shutil.copytree(tokenizer_dir, output_dir, dirs_exist_ok=True)
+
+
+def _resize_vocab_tensor_rows(tensor: torch.Tensor, target_size: int) -> torch.Tensor:
+    current_size = tensor.shape[0]
+    if current_size == target_size:
+        return tensor
+    if current_size > target_size:
+        return tensor[:target_size].clone()
+    new_shape = (target_size, *tensor.shape[1:])
+    resized = tensor.new_zeros(new_shape)
+    resized[:current_size] = tensor
+    return resized
+
+
+def _resize_vocab_bias(bias: torch.Tensor, target_size: int) -> torch.Tensor:
+    current_size = bias.shape[0]
+    if current_size == target_size:
+        return bias
+    if current_size > target_size:
+        return bias[:target_size].clone()
+    resized = bias.new_zeros(target_size)
+    resized[:current_size] = bias
+    return resized
+
+
+def _align_vocab_size(weights: OrderedDict, target_vocab_size: int) -> None:
+    embedding_rows = weights["embeddings.word_embeddings.weight"].shape[0]
+    decoder_rows = weights["lm_head.decoder.weight"].shape[0]
+    decoder_bias_rows = weights["lm_head.decoder.bias"].shape[0]
+    current_sizes = {embedding_rows, decoder_rows, decoder_bias_rows}
+    if len(current_sizes) != 1:
+        raise ValueError(
+            "Checkpoint vocab tensors are inconsistent: "
+            f"embeddings={embedding_rows}, decoder={decoder_rows}, decoder_bias={decoder_bias_rows}."
+        )
+    if embedding_rows != target_vocab_size:
+        print(
+            "Vocab size mismatch: checkpoint tensors have "
+            f"{embedding_rows} rows while config expects {target_vocab_size}. Resizing embedding and MLM decoder tensors."
+        )
+    weights["embeddings.word_embeddings.weight"] = _resize_vocab_tensor_rows(
+        weights["embeddings.word_embeddings.weight"], target_vocab_size
+    )
+    weights["lm_head.decoder.weight"] = _resize_vocab_tensor_rows(weights["lm_head.decoder.weight"], target_vocab_size)
+    weights["lm_head.decoder.bias"] = _resize_vocab_bias(weights["lm_head.decoder.bias"], target_vocab_size)
+
+
+def convert(
+    path,
+    version: str = "single",
+    num_hidden_layers: int = 12,
+    hidden_size: int = 768,
+    vocab_size: int = 10,
+):
+    version = _validate_version(version)
+    output_dir = _resolve_output_dir(path)
     if version == "single":
         config = build_config(path)
-        if os.path.exists(config._name_or_path):
-            shutil.rmtree(config._name_or_path)
-        shutil.copytree(os.path.join(os.path.dirname(__file__), "tokenizer/single"), config._name_or_path)
+        _prepare_output_dir(output_dir, "single")
     elif version == "bpe":
+        num_hidden_layers, hidden_size, vocab_size = _validate_gene_dims(num_hidden_layers, hidden_size, vocab_size)
         config = build_config_GENE(path, num_hidden_layers, hidden_size, vocab_size)
-        if os.path.exists(config._name_or_path):
-            shutil.rmtree(config._name_or_path)
-        shutil.copytree(os.path.join(os.path.dirname(__file__), "tokenizer/bpe"), config._name_or_path)
+        _prepare_output_dir(output_dir, "bpe")
     elif version == "plant_bpe":
+        num_hidden_layers, hidden_size, vocab_size = _validate_gene_dims(num_hidden_layers, hidden_size, vocab_size)
         config = build_config_GENE(path, num_hidden_layers, hidden_size, vocab_size)
-        if os.path.exists(config._name_or_path):
-            shutil.rmtree(config._name_or_path)
-        shutil.copytree(os.path.join(os.path.dirname(__file__), "tokenizer/plant_bpe"), config._name_or_path)
-    else:
-        AssertionError("Invalid version for tokenizer")
+        _prepare_output_dir(output_dir, "plant_bpe")
 
+    config._name_or_path = str(output_dir)
     config.save_pretrained(config._name_or_path)
     ckpt = torch.load(path)
     weights = convert_ckpt(ckpt["model"])
-    if config.vocab_size != weights["embeddings.word_embeddings.weight"].shape[0]:
-        print(
-            f"Vocab size mismatch, loaded model weights have {weights['embeddings.word_embeddings.weight'].shape[0]} tokens, while config has {config.vocab_size} tokens. \nTruncating the weights."
-        )
-        weights["embeddings.word_embeddings.weight"] = weights["embeddings.word_embeddings.weight"][: config.vocab_size]
+    _align_vocab_size(weights, config.vocab_size)
     torch.save(weights, os.path.join(config._name_or_path, "pytorch_model.bin"))
 
 
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Convert UniRNA checkpoints into Hugging Face model packages.")
+    parser.add_argument("checkpoint_path", help="Path to the source checkpoint file.")
+    parser.add_argument(
+        "--version",
+        default="single",
+        choices=sorted(SUPPORTED_TOKENIZER_VERSIONS),
+        help="Tokenizer/config conversion preset.",
+    )
+    parser.add_argument("--num-hidden-layers", type=int, default=12, help="Number of transformer layers for GENE models.")
+    parser.add_argument("--hidden-size", type=int, default=768, help="Hidden size for GENE models.")
+    parser.add_argument("--vocab-size", type=int, default=10, help="Vocabulary size for GENE models.")
+    return parser
+
+
+def cli_main(argv=None):
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    convert(
+        args.checkpoint_path,
+        version=args.version,
+        num_hidden_layers=args.num_hidden_layers,
+        hidden_size=args.hidden_size,
+        vocab_size=args.vocab_size,
+    )
+
+
 if __name__ == "__main__":
-    if len(sys.argv) < 3:
-        convert(sys.argv[1])
-    else:
-        print("You choose GENE model. Please provide num_hidden_layers and hidden_size.")
-        num_hidden_layers = int(input("nums_layers: "))
-        hidden_size = int(input("hidden_size: "))
-        vocab_size = int(input("vocab_size: "))
-        convert(sys.argv[1], sys.argv[2], num_hidden_layers, hidden_size, vocab_size)
+    cli_main(sys.argv[1:])


### PR DESCRIPTION
## Summary
- declare the runtime dependencies needed for package import, inference, and checkpoint conversion, and add a build-model CLI entry point
- make checkpoint conversion validate tokenizer presets clearly, write outputs next to the source checkpoint, and avoid deleting unrelated directories
- keep vocab resizing consistent across embedding and MLM decoder tensors and add focused regression tests for conversion edge cases

## Testing
- PYTHONPATH=. pytest -q